### PR TITLE
Implement same behavior in GUI as in CLI about text with accents

### DIFF
--- a/Source/GUI/Qt/GUI_Main_Core_Table.cpp
+++ b/Source/GUI/Qt/GUI_Main_Core_Table.cpp
@@ -99,7 +99,7 @@ void GUI_Main_Core_Table::contextMenuEvent (QContextMenuEvent* Event)
         //Handling date display
         if (!Date.empty())
         {
-            menu.addAction(new QAction(QString().fromUtf8(Date.To_Local().c_str()), this));
+            menu.addAction(new QAction(QString().fromLocal8Bit(Date.To_Local().c_str()), this));
             menu.addSeparator();
         }
 
@@ -110,7 +110,7 @@ void GUI_Main_Core_Table::contextMenuEvent (QContextMenuEvent* Event)
             {
                 Pos--;
 
-                QString Text=QString().fromUtf8(History[Pos].To_Local().c_str());
+                QString Text=QString().fromLocal8Bit(History[Pos].To_Local().c_str());
                 if (!Text.isEmpty())
                 {
                     QAction* Action=new QAction(Text, this);
@@ -132,7 +132,7 @@ void GUI_Main_Core_Table::contextMenuEvent (QContextMenuEvent* Event)
         {
             for (int Row=0; Row<rowCount(); Row++)
             {
-                item(Row, Item->column())->setText(QString().fromUtf8(Ztring(C->Get(FileName, Field)).To_Local().c_str()));
+                item(Row, Item->column())->setText(QString::fromLocal8Bit(Ztring(C->Get(FileName, Field)).To_Local().c_str()));
                 dataChanged(indexFromItem(item(Row, Item->column())), indexFromItem(item(Row, Item->column())));
 
                 //Changing BextVersion Enabled value
@@ -150,7 +150,7 @@ void GUI_Main_Core_Table::contextMenuEvent (QContextMenuEvent* Event)
             Text=Text.remove("&Set ICRD to file creation timestamp ("); //If you change this, change the creation text too
             Text=Text.remove("&Set originationDate and Time to file creation timestamp ("); //If you change this, change the creation text too
             Text=Text.remove(")"); //If you change this, change the creation text too
-            if (horizontalHeaderItem(Item->column())->text()==QString().fromUtf8("ICRD"))
+            if (horizontalHeaderItem(Item->column())->text()==QString().fromLocal8Bit("ICRD"))
             {
                 item(Item->row(), Item->column())->setText(Text);
                 dataChanged(indexFromItem(item(Item->row(), Item->column())), indexFromItem(item(Item->row(), Item->column())));
@@ -162,8 +162,8 @@ void GUI_Main_Core_Table::contextMenuEvent (QContextMenuEvent* Event)
                 QString Time=Text;
                 Time.remove(0, 10+1);
                 Time.remove(8, 4);
-                int Date_Pos=Item->column()+(horizontalHeaderItem(Item->column())->text()==QString().fromUtf8("OriginationDate")?0:-1);
-                int Time_Pos=Item->column()+(horizontalHeaderItem(Item->column())->text()==QString().fromUtf8("OriginationTime")?0:1);
+                int Date_Pos=Item->column()+(horizontalHeaderItem(Item->column())->text()==QString().fromLocal8Bit("OriginationDate")?0:-1);
+                int Time_Pos=Item->column()+(horizontalHeaderItem(Item->column())->text()==QString().fromLocal8Bit("OriginationTime")?0:1);
                 item(Item->row(), Date_Pos)->setText(Date);
                 dataChanged(indexFromItem(item(Item->row(), Date_Pos)), indexFromItem(item(Item->row(), Date_Pos)));
                 item(Item->row(), Time_Pos)->setText(Time);
@@ -300,7 +300,7 @@ bool GUI_Main_Core_Table::edit (const QModelIndex &index, EditTrigger trigger, Q
         //Filling
         Ztring NewValue(C->Get(FileName, Field));
         NewValue.FindAndReplace("\r\n", "\n", 0, Ztring_Recursive);
-        item(index.row(), index.column())->setText(NewValue.c_str());
+        item(index.row(), index.column())->setText(QString::fromLocal8Bit(NewValue.c_str()));
         if (Field=="Originator")
             SetText(index, "IARL"); //IARL is sometimes updated if Originator is modified
 
@@ -326,7 +326,7 @@ bool GUI_Main_Core_Table::edit (const QModelIndex &index, EditTrigger trigger, Q
         //Filling
         Ztring NewValue(C->Get(FileName, Field));
         NewValue.FindAndReplace("\r\n", "\n", 0, Ztring_Recursive);
-        item(index.row(), index.column())->setText(NewValue.c_str());
+        item(index.row(), index.column())->setText(QString::fromLocal8Bit(NewValue.c_str()));
 
         //Changing BextVersion Enabled value
         SetText   (index, "BextVersion");
@@ -396,7 +396,7 @@ bool GUI_Main_Core_Table::edit (const QModelIndex &index, EditTrigger trigger, Q
         //Updating
         Ztring NewValue(C->Get(FileName, Field));
         NewValue.FindAndReplace("\r\n", "\n", 0, Ztring_Recursive);
-        item(index.row(), index.column())->setText(NewValue.c_str());
+        item(index.row(), index.column())->setText(QString::fromLocal8Bit(NewValue.c_str()));
 
         //Changing BextVersion Enabled value
         SetText   (index, "BextVersion");
@@ -443,7 +443,7 @@ bool GUI_Main_Core_Table::edit (const QModelIndex &index, EditTrigger trigger, Q
         //Updating
         Ztring NewValue(C->Get(FileName, Field));
         NewValue.FindAndReplace("\r\n", "\n", 0, Ztring_Recursive);
-        item(index.row(), index.column())->setText(NewValue.c_str());
+        item(index.row(), index.column())->setText(QString::fromLocal8Bit(NewValue.c_str()));
 
         //Changing BextVersion Enabled value
         SetText   (index, "BextVersion");
@@ -467,7 +467,7 @@ bool GUI_Main_Core_Table::edit (const QModelIndex &index, EditTrigger trigger, Q
         //Updating
         Ztring NewValue(C->Get(FileName, Field));
         NewValue.FindAndReplace("\r\n", "\n", 0, Ztring_Recursive);
-        item(index.row(), index.column())->setText(NewValue.c_str());
+        item(index.row(), index.column())->setText(QString::fromLocal8Bit(NewValue.c_str()));
 
         //Changing BextVersion Enabled value
         SetText   (index, "BextVersion");

--- a/Source/GUI/Qt/GUI_Main_Core_Table.cpp
+++ b/Source/GUI/Qt/GUI_Main_Core_Table.cpp
@@ -286,7 +286,7 @@ bool GUI_Main_Core_Table::edit (const QModelIndex &index, EditTrigger trigger, Q
         ModifiedContentQ=index.model()->data(index.model()->index(index.row(), index.column(), rootIndex())).toString(); //Old value
 
     //Description / Originator / OriginatorReference
-    if (Field=="Description" || Field=="Originator" || Field=="OriginatorReference" || Field=="IARL") 
+    if (Field=="Description" || Field=="Originator" || Field=="OriginatorReference" || Field=="IARL" || Field=="IART" || Field=="ICMS" || Field=="ICMT" || Field=="ICOP" || Field=="IENG" || Field=="IGNR" || Field=="IKEY" || Field=="IMED" || Field=="INAM" || Field=="IPRD" || Field=="ISBJ" || Field=="ISFT" || Field=="ISRC" || Field=="ISRF" || Field=="ITCH") //Most INFO fields added in order to permit to show warning 
     {
         //User interaction
         GUI_Main_xxxx_TextEditDialog* Edit=new GUI_Main_xxxx_TextEditDialog(C, FileName, Field, ModifiedContentQ);

--- a/Source/GUI/Qt/GUI_Main_Core_Text.cpp
+++ b/Source/GUI/Qt/GUI_Main_Core_Text.cpp
@@ -41,7 +41,7 @@ bool GUI_Main_Core_Text::event (QEvent *Event)
     {
         //Showing
         clear();
-        insertPlainText(QString().fromUtf8(ZenLib::Ztring(C->Core_Get()).To_Local().c_str()));
+        insertPlainText(QString().fromLocal8Bit(ZenLib::Ztring(C->Core_Get()).To_Local().c_str()));
         
         //Event accepting
         Event->accept();

--- a/Source/GUI/Qt/GUI_Main_Menu.cpp
+++ b/Source/GUI/Qt/GUI_Main_Menu.cpp
@@ -247,10 +247,10 @@ void GUI_Main::Menu_Create()
     for (size_t Group=0; Group<Preferences->Groups_Count_Get(); Group++)
     {
         if (Preferences->Group_Options_Count_Get((group)Group, true))
-            Menu_Fields_Menus[Group]=Menu_Fields_Main->addMenu(QString().fromUtf8(Preferences->Group_Name_Get((group)Group).c_str()));
+            Menu_Fields_Menus[Group]=Menu_Fields_Main->addMenu(QString().fromLocal8Bit(Preferences->Group_Name_Get((group)Group).c_str()));
         for (size_t Option=0; Option<Preferences->Group_Options_Count_Get((group)Group, true); Option++)
         {
-            Menu_Fields_CheckBoxes[Group*options::MaxCount+Option] = new QAction(QString().fromUtf8(Preferences->Group_Option_Description_Get((group)Group, Option).c_str()), this);
+            Menu_Fields_CheckBoxes[Group*options::MaxCount+Option] = new QAction(QString().fromLocal8Bit(Preferences->Group_Option_Description_Get((group)Group, Option).c_str()), this);
             Menu_Fields_Menus[Group]->addAction(Menu_Fields_CheckBoxes[Group*options::MaxCount+Option]);
             Menu_Fields_CheckBoxes[Group*options::MaxCount+Option]->setCheckable(true);
         }

--- a/Source/GUI/Qt/GUI_Main_Output_Log.cpp
+++ b/Source/GUI/Qt/GUI_Main_Output_Log.cpp
@@ -46,9 +46,9 @@ bool GUI_Main_Output_Log::event (QEvent *Event)
         clear();
         switch (KindOfLog)
         {
-            case 1 : setPlainText(QString().fromUtf8(ZenLib::Ztring(C->Text_stdout.str()).To_Local().c_str())); break;
-            case 2 : setPlainText(QString().fromUtf8(ZenLib::Ztring(C->Text_stderr.str()).To_Local().c_str())); break;
-            case 3 : setPlainText(QString().fromUtf8(ZenLib::Ztring(C->Text_stdall.str()).To_Local().c_str())); break;
+            case 1 : setPlainText(QString().fromLocal8Bit(ZenLib::Ztring(C->Text_stdout.str()).To_Local().c_str())); break;
+            case 2 : setPlainText(QString().fromLocal8Bit(ZenLib::Ztring(C->Text_stderr.str()).To_Local().c_str())); break;
+            case 3 : setPlainText(QString().fromLocal8Bit(ZenLib::Ztring(C->Text_stdall.str()).To_Local().c_str())); break;
             default: ;
         }
 

--- a/Source/GUI/Qt/GUI_Main_Output_Trace.cpp
+++ b/Source/GUI/Qt/GUI_Main_Output_Trace.cpp
@@ -50,7 +50,7 @@ bool GUI_Main_Trace::event (QEvent *Event)
     {
         //Showing
         clear();
-        setPlainText(QString().fromUtf8(C->Output_Trace_Get().c_str()));
+        setPlainText(QString().fromLocal8Bit(C->Output_Trace_Get().c_str()));
 
         Event->accept();
         return true;

--- a/Source/GUI/Qt/GUI_Main_Technical_Table.cpp
+++ b/Source/GUI/Qt/GUI_Main_Technical_Table.cpp
@@ -84,16 +84,16 @@ void GUI_Main_Technical_Table::contextMenuEvent (QContextMenuEvent* Event)
 
     //Handling export display
     if (!Import.empty())
-        menu.addAction(new QAction(QString().fromUtf8(Import.To_Local().c_str()), this));
+        menu.addAction(new QAction(QString().fromLocal8Bit(Import.To_Local().c_str()), this));
     if (!Export.empty())
-        menu.addAction(new QAction(QString().fromUtf8(Export.To_Local().c_str()), this));
+        menu.addAction(new QAction(QString().fromLocal8Bit(Export.To_Local().c_str()), this));
     if (!Import.empty() || !Export.empty())
         menu.addSeparator();
 
     //Handling Fill display
     if (!Fill.empty())
     {
-        menu.addAction(new QAction(QString().fromUtf8(Fill.To_Local().c_str()), this));
+        menu.addAction(new QAction(QString().fromLocal8Bit(Fill.To_Local().c_str()), this));
         menu.addSeparator();
     }
 
@@ -104,7 +104,7 @@ void GUI_Main_Technical_Table::contextMenuEvent (QContextMenuEvent* Event)
         {
             Pos--;
 
-            QString Text=QString().fromUtf8(History[Pos].To_Local().c_str());
+            QString Text=QString().fromLocal8Bit(History[Pos].To_Local().c_str());
             if (!Text.isEmpty())
             {
                 QAction* Action=new QAction(Text, this);
@@ -117,7 +117,7 @@ void GUI_Main_Technical_Table::contextMenuEvent (QContextMenuEvent* Event)
     if (!Remove.empty())
     {
         menu.addSeparator();
-        menu.addAction(new QAction(QString().fromUtf8(Remove.To_Local().c_str()), this));
+        menu.addAction(new QAction(QString().fromLocal8Bit(Remove.To_Local().c_str()), this));
     }
 
     //Displaying
@@ -294,7 +294,7 @@ bool GUI_Main_Technical_Table::edit (const QModelIndex &index, EditTrigger trigg
             Ztring NewValue(C->Get(FileName, "BextVersion"));
 
             //Updating
-            item(index.row(), index.column())->setText(("Version "+NewValue).c_str());
+            item(index.row(), index.column())->setText(QString::fromLocal8Bit(("Version "+NewValue).c_str()));
             dataChanged(indexFromItem(item(index.row(), index.column())), indexFromItem(item(index.row(), index.column())));
             return false;
         }
@@ -310,7 +310,7 @@ bool GUI_Main_Technical_Table::edit (const QModelIndex &index, EditTrigger trigg
         {
             Ztring ModifiedContent=C->Get(FileName, Field);
             ModifiedContent.FindAndReplace("\r\n", "\n", 0, Ztring_Recursive);
-            ModifiedContentQ=QString().fromUtf8(ModifiedContent.To_Local().c_str());
+            ModifiedContentQ=QString::fromLocal8Bit(ModifiedContent.To_Local().c_str());
         }
 
         //User interaction
@@ -343,7 +343,7 @@ bool GUI_Main_Technical_Table::edit (const QModelIndex &index, EditTrigger trigg
         //Filling
         Ztring NewValue(C->Get(FileName, Field));
         NewValue.FindAndReplace("\r\n", "\n", 0, Ztring_Recursive);
-        item(index.row(), index.column())->setText(NewValue.c_str());
+        item(index.row(), index.column())->setText(QString::fromLocal8Bit(NewValue.c_str()));
         return false;
     }
 

--- a/Source/GUI/Qt/GUI_Main_Technical_Text.cpp
+++ b/Source/GUI/Qt/GUI_Main_Technical_Text.cpp
@@ -43,7 +43,7 @@ bool GUI_Main_Technical_Text::event (QEvent *Event)
     {
         //Showing
         clear();
-        setPlainText(QString().fromUtf8(ZenLib::Ztring(C->Technical_Get()).To_Local().c_str()));
+        setPlainText(QString().fromLocal8Bit(ZenLib::Ztring(C->Technical_Get()).To_Local().c_str()));
 
         Event->accept();
         return true;

--- a/Source/GUI/Qt/GUI_Main_UndoDialog.cpp
+++ b/Source/GUI/Qt/GUI_Main_UndoDialog.cpp
@@ -67,7 +67,7 @@ GUI_Main_UndoDialog::GUI_Main_UndoDialog(Core* _C, QWidget* parent)
     //Fill
     ZtringList List=C->Menu_File_Undo_ListBackupFiles();
     for (size_t Pos=0; Pos<List.size(); Pos++)
-        ListWidget->addItem(QString().fromUtf8(List[Pos].To_Local().c_str()));
+        ListWidget->addItem(QString().fromLocal8Bit(List[Pos].To_Local().c_str()));
 }
 
 //***************************************************************************
@@ -78,6 +78,6 @@ void GUI_Main_UndoDialog::currentItemChanged (QListWidgetItem* Current, QListWid
 {
     Ztring ToDisplay=C->Menu_File_Undo_ListModifiedFiles(ListWidget->currentRow());
 
-    ListInfo->setText(QString().fromUtf8(ToDisplay.To_Local().c_str()));
+    ListInfo->setText(QString().fromLocal8Bit(ToDisplay.To_Local().c_str()));
 }
 

--- a/Source/GUI/Qt/GUI_Main_xxxx_CodingHistoryDialog.cpp
+++ b/Source/GUI/Qt/GUI_Main_xxxx_CodingHistoryDialog.cpp
@@ -338,7 +338,7 @@ void GUI_Main_xxxx_CodingHistoryDialog::OnMenu_Load()
     delete[] Buffer;
     ModifiedContent.FindAndReplace("\r\n", "\n", 0, Ztring_Recursive);
     ModifiedContent.FindAndReplace("\r", "\n", 0, Ztring_Recursive);
-    QString ModifiedContentQ=QString().fromUtf8(ModifiedContent.To_Local().c_str());
+    QString ModifiedContentQ=QString().fromLocal8Bit(ModifiedContent.To_Local().c_str());
 
     TextEdit->setPlainText(ModifiedContentQ);
     if (Central->currentIndex()==0)
@@ -428,7 +428,7 @@ void GUI_Main_xxxx_CodingHistoryDialog::List2Text ()
     }
     
     if (!ToReturn.empty())
-        TextEdit->setPlainText(ToReturn.To_Local().c_str());
+        TextEdit->setPlainText(QString::fromLocal8Bit(ToReturn.To_Local().c_str()));
 }
 
 //---------------------------------------------------------------------------
@@ -497,7 +497,7 @@ void GUI_Main_xxxx_CodingHistoryDialog::Text2List ()
                     Modified=true;
                     Value="ANALOGUE";
                 }
-                QTableWidgetItem* Item=new QTableWidgetItem(QString().fromUtf8(Value.To_Local().c_str()));
+                QTableWidgetItem* Item=new QTableWidgetItem(QString().fromLocal8Bit(Value.To_Local().c_str()));
             
                 Table->setItem((int)Line_Pos, Column, Item);
             }

--- a/Source/GUI/Qt/GUI_Main_xxxx_DateDialog.cpp
+++ b/Source/GUI/Qt/GUI_Main_xxxx_DateDialog.cpp
@@ -46,7 +46,7 @@ GUI_Main_xxxx_DateDialog::GUI_Main_xxxx_DateDialog(Core* _C, const std::string &
 
     //Configuration
     setWindowFlags(windowFlags()&(0xFFFFFFFF-Qt::WindowContextHelpButtonHint));
-    setWindowTitle(QString::fromUtf8(Field.c_str()));
+    setWindowTitle(QString::fromLocal8Bit(Field.c_str()));
     setWindowIcon (QIcon(":/Image/FADGI/Logo.png"));
 
     //Buttons
@@ -56,7 +56,7 @@ GUI_Main_xxxx_DateDialog::GUI_Main_xxxx_DateDialog(Core* _C, const std::string &
     Date=NULL;
     if (Field=="OriginationDate")
     {
-        QString DateQ=QString().fromUtf8(ZenLib::Ztring(C->FileDate_Get(FileName)).To_Local().c_str());
+        QString DateQ=QString().fromLocal8Bit(ZenLib::Ztring(C->FileDate_Get(FileName)).To_Local().c_str());
         if (DateQ.size()>10)
         {
             DateQ.truncate(10);
@@ -70,7 +70,7 @@ GUI_Main_xxxx_DateDialog::GUI_Main_xxxx_DateDialog(Core* _C, const std::string &
     }
     if (Field=="OriginationTime")
     {
-        QString TimeQ=QString().fromUtf8(ZenLib::Ztring(C->FileDate_Get(FileName)).To_Local().c_str());
+        QString TimeQ=QString().fromLocal8Bit(ZenLib::Ztring(C->FileDate_Get(FileName)).To_Local().c_str());
         if (TimeQ.size()>10)
         {
             TimeQ.remove(0, 10+1);
@@ -180,7 +180,7 @@ void GUI_Main_xxxx_DateDialog::OnTextChanged ()
     std::string Value=TextEdit->toPlainText().toLocal8Bit().data();
     if (!C->IsValid(FileName, Field, Value))
     {
-        Label->setText(QString::fromUtf8(C->IsValid_LastError(FileName).c_str()));
+        Label->setText(QString::fromLocal8Bit(C->IsValid_LastError(FileName).c_str()));
         Dialog->button(QDialogButtonBox::Ok)->setEnabled(false);
     }
     else
@@ -258,7 +258,7 @@ void GUI_Main_xxxx_DateDialog::OnMenu_Calendar ()
         {
             TimeEdit->setVisible(true);
             TimeEdit_Activated->setChecked(true);
-            TimeEdit->setTime(QTime::fromString(QString().fromUtf8(Value.To_Local().c_str()), Qt::ISODate));
+            TimeEdit->setTime(QTime::fromString(QString().fromLocal8Bit(Value.To_Local().c_str()), Qt::ISODate));
         }
     }
     OnCalendar_Changed();

--- a/Source/GUI/Qt/GUI_Main_xxxx_TextEditDialog.cpp
+++ b/Source/GUI/Qt/GUI_Main_xxxx_TextEditDialog.cpp
@@ -117,7 +117,22 @@ void GUI_Main_xxxx_TextEditDialog::OnTextChanged ()
     }
     else
     {
-        Label->setText(QString());
+        bool IsASCII=true;
+        for (size_t i=0; i<Value.size(); i++)
+            if (((unsigned char)Value[i]) >= 0x80)
+            {
+                IsASCII = false;
+                break;
+            }
+        if (IsASCII)
+            Label->setText(QString());
+        else
+        {
+            if (Field=="Description" || Field=="Originator" || Field=="OriginatorReference")
+                Label->setText("Warning: due to the presence of non ASCII characters, which are forbidden by EBU Text 3285 specifications,<br />there is a risk of interoperability issues with other tools (including BWF MetaEdit on other platforms)<br />as the content is converted with local codepage");
+            else
+                Label->setText("Warning: due to the presence of non ASCII characters, whose the encoding in files is not specified in WAV documents,<br />there is a risk of interoperability issues with other tools (including BWF MetaEdit on other platforms)<br />as the content is converted with local codepage");
+        }
         Dialog->button(QDialogButtonBox::Ok)->setEnabled(true);
     }
 }

--- a/Source/GUI/Qt/GUI_Main_xxxx_TextEditDialog.cpp
+++ b/Source/GUI/Qt/GUI_Main_xxxx_TextEditDialog.cpp
@@ -39,7 +39,7 @@ GUI_Main_xxxx_TextEditDialog::GUI_Main_xxxx_TextEditDialog(Core* _C, const std::
 
     //Configuration
     setWindowFlags(windowFlags()&(0xFFFFFFFF-Qt::WindowContextHelpButtonHint));
-    setWindowTitle(QString::fromUtf8(Field.c_str()));
+    setWindowTitle(QString::fromLocal8Bit(Field.c_str()));
     setWindowIcon (QIcon(":/Image/FADGI/Logo.png"));
 
     //Buttons
@@ -112,7 +112,7 @@ void GUI_Main_xxxx_TextEditDialog::OnTextChanged ()
         Label->setText("<html><body>This tool does not validate the contents of the XML chunks as XML nor against the rules for iXML.<br />Edit at your own risk. For more information see the <a href=\"http://www.gallery.co.uk/ixml/\">iXML Specification</a><br />Edits to this chunk can not be undone</body></html>");
     else if (!C->IsValid(FileName, Field, Value))
     {
-        Label->setText(QString::fromUtf8(C->IsValid_LastError(FileName).c_str()));
+        Label->setText(QString::fromLocal8Bit(C->IsValid_LastError(FileName).c_str()));
         Dialog->button(QDialogButtonBox::Ok)->setEnabled(false);
     }
     else
@@ -162,7 +162,7 @@ void GUI_Main_xxxx_TextEditDialog::OnMenu_Load()
     delete[] Buffer;
     ModifiedContent.FindAndReplace("\r\n", "\n", 0, Ztring_Recursive);
     ModifiedContent.FindAndReplace("\r", "\n", 0, Ztring_Recursive);
-    QString ModifiedContentQ=QString().fromUtf8(ModifiedContent.To_Local().c_str());
+    QString ModifiedContentQ=QString().fromLocal8Bit(ModifiedContent.To_Local().c_str());
 
     TextEdit->setPlainText(ModifiedContentQ);
 }

--- a/Source/GUI/Qt/GUI_Main_xxxx_TimeReferenceDialog.cpp
+++ b/Source/GUI/Qt/GUI_Main_xxxx_TimeReferenceDialog.cpp
@@ -76,7 +76,7 @@ GUI_Main_xxxx_TimeReferenceDialog::GUI_Main_xxxx_TimeReferenceDialog(Core* _C, c
     SampleRate=Ztring(C->Get(FileName, "SampleRate")).To_int64u();
     Ztring TimeReference=C->Get(FileName, "TimeReference");
     Ztring TimeReferenceS=C->Get(FileName, "TimeReference (translated)");
-    TimeEdit->setTime(QTime::fromString(QString().fromUtf8(TimeReferenceS.To_Local().c_str()), Qt::ISODate));
+    TimeEdit->setTime(QTime::fromString(QString().fromLocal8Bit(TimeReferenceS.To_Local().c_str()), Qt::ISODate));
     LineEdit->setValue(TimeReference.To_int32u());
     IsChanging=false;
 }

--- a/Source/GUI/Qt/GUI_Main_xxxx_UmidDialog.cpp
+++ b/Source/GUI/Qt/GUI_Main_xxxx_UmidDialog.cpp
@@ -982,7 +982,7 @@ void GUI_Main_xxxx_UmidDialog::OnTextChanged (const QString &)
 
     if (!C->IsValid(FileName, Field, Value))
     {
-        Label->setText(QString::fromUtf8(C->IsValid_LastError(FileName).c_str()));
+        Label->setText(QString::fromLocal8Bit(C->IsValid_LastError(FileName).c_str()));
         Dialog->button(QDialogButtonBox::Ok)->setEnabled(false);
     }
     else

--- a/Source/GUI/Qt/GUI_Main_xxxx__Common.cpp
+++ b/Source/GUI/Qt/GUI_Main_xxxx__Common.cpp
@@ -296,7 +296,7 @@ void GUI_Main_xxxx__Common::SetText (int Row, const QString &Field)
         if (Field_Current==Field)
         {
             string FileName=FileName_Before+item(Row, 0)->text().toLocal8Bit().data();
-            item(Row, Column)->setText(C->Get(FileName, Field.toLocal8Bit().data()).c_str());
+            item(Row, Column)->setText(QString::fromLocal8Bit(C->Get(FileName, Field.toLocal8Bit().data()).c_str()));
             dataChanged(indexFromItem(item(Row, Column)), indexFromItem(item(Row, Column)));
             //Colors_Update(item(Row, Column), FileName, Field.toLocal8Bit().data());
             return;
@@ -376,7 +376,7 @@ void GUI_Main_xxxx__Common::Fill ()
     for (size_t Data_Pos=0; Data_Pos<List[0].size(); Data_Pos++)
         if (Data_Pos==0 || Main->Menu_Fields_CheckBoxes[Fill_Group()*options::MaxCount+Data_Pos-1]->isChecked())
         {
-            QTableWidgetItem* Item=new QTableWidgetItem(QString().fromUtf8(List[0][Data_Pos].To_Local().c_str()));
+            QTableWidgetItem* Item=new QTableWidgetItem(QString().fromLocal8Bit(List[0][Data_Pos].To_Local().c_str()));
             Item->setToolTip(Columns_ToolTip(List[0][Data_Pos]));
             setHorizontalHeaderItem((int)(Data_Pos-ColumnMissing_Count), Item);
         }
@@ -396,7 +396,7 @@ void GUI_Main_xxxx__Common::Fill ()
                 if (Data_Pos<List[File_Pos].size())
                 {
                     ZenLib::Ztring Value=List[File_Pos][Data_Pos];
-                    Item=new QTableWidgetItem(QString().fromUtf8(Value.To_Local().c_str()));
+                    Item=new QTableWidgetItem(QString().fromLocal8Bit(Value.To_Local().c_str()));
                     Item->setToolTip(Columns_ToolTip(List[0][Data_Pos]));
                 }
                 else


### PR DESCRIPTION
Using local code page (which is not very good, because it depends on the OS e.g. macOS has now UTF-8 as local code page in the US and Windows has still Latin1, so files are not compatible between macOS and Windows; but as it is already the current CLI behavior, this is not worse than before).
