### PR TITLE
IsOrignal() returns always false for mutilines values on Unix platforms

### DIFF
--- a/Source/Riff/Riff_Chunks_WAVE_bext.cpp
+++ b/Source/Riff/Riff_Chunks_WAVE_bext.cpp
@@ -228,7 +228,7 @@ void Riff_WAVE_bext::Read_Internal ()
     for (std::map<string, string>::iterator String=Global->bext->Strings.begin(); String!=Global->bext->Strings.end(); String++)
     {
         Ztring temp=Ztring().From_UTF8(String->second);
-        temp.FindAndReplace(__T("\n"), EOL, 0, Ztring_Recursive);
+        temp.FindAndReplace(__T("\n"), __T("\r\n"), 0, Ztring_Recursive);
         String->second=temp.To_UTF8();
     }
 }

--- a/Source/Riff/Riff_Handler.cpp
+++ b/Source/Riff/Riff_Handler.cpp
@@ -439,8 +439,14 @@ string Riff_Handler::Get_Internal(const string &Field)
     Riff_Base::global::chunk_strings** Chunk_Strings=chunk_strings_Get(Field);
     if (!Chunk_Strings || !*Chunk_Strings)
         return string();
+
+    Ztring Value=Ztring().From_UTF8(Get(Field_Get(Field), *Chunk_Strings));
+    Value.FindAndReplace(__T("\r\n"), __T("\n"), 0, Ztring_Recursive);
+    Value.FindAndReplace(__T("\n\r"), __T("\n"), 0, Ztring_Recursive); //Bug in v0.2.1 XML, \r\n was inverted
+    Value.FindAndReplace(__T("\r"), __T("\n"), 0, Ztring_Recursive);
+    Value.FindAndReplace(__T("\n"), EOL, 0, Ztring_Recursive);
     
-    return Get(Field_Get(Field), *Chunk_Strings);
+    return Value.To_UTF8();
 }
 
 //---------------------------------------------------------------------------


### PR DESCRIPTION
Signed-off-by: Maxime Gervais <gervais.maxime@gmail.com>