### PR TITLE
Custom values input in coding history table dialog.

### DIFF
--- a/Source/GUI/Qt/GUI_Main_xxxx_CodingHistoryDialog.cpp
+++ b/Source/GUI/Qt/GUI_Main_xxxx_CodingHistoryDialog.cpp
@@ -99,15 +99,17 @@ void CodingHistoryDialog_TableWidget::dataChanged ( const QModelIndex & topLeft,
 //***************************************************************************
 
 //---------------------------------------------------------------------------
-CodingHistoryDialog_Delegate::CodingHistoryDialog_Delegate(QObject *parent)
+CodingHistoryDialog_Delegate::CodingHistoryDialog_Delegate(bool Rules_Recommendations_, QObject *parent)
 : QItemDelegate(parent)
 {
+    Rules_Recommendations=Rules_Recommendations_;
 }
 
 //---------------------------------------------------------------------------
 QWidget *CodingHistoryDialog_Delegate::createEditor(QWidget *parent, const QStyleOptionViewItem &/* option */, const QModelIndex &/* index */) const
 {
     QComboBox* Editor=new QComboBox(parent);
+    Editor->setEditable(!Rules_Recommendations);
     Editor->installEventFilter(const_cast<CodingHistoryDialog_Delegate*>(this));
 
     return Editor;
@@ -120,10 +122,17 @@ void CodingHistoryDialog_Delegate::setEditorData(QWidget *editor, const QModelIn
     QComboBox* Editor=static_cast<QComboBox*>(editor);
 
     Fill(Editor);
-    
+
+    bool Found=false;
     for (int Pos=0; Pos<Editor->count(); Pos++)
         if (Value==Editor->itemText(Pos))
+         {
+            Found=true;
             Editor->setCurrentIndex(Pos);
+         }
+
+    if (!Rules_Recommendations && !Value.isEmpty() && !Found)
+        Editor->setCurrentText(Value);
 }
 
 //---------------------------------------------------------------------------
@@ -525,11 +534,11 @@ void GUI_Main_xxxx_CodingHistoryDialog::Text2List ()
         }
     }
 
-    Table->setItemDelegateForColumn(0, new CodingAlgorithmDelegate);
-    Table->setItemDelegateForColumn(1, new SamplingFrequencyDelegate);
-    Table->setItemDelegateForColumn(2, new BitRateDelegate);
-    Table->setItemDelegateForColumn(3, new WordLengthDelegate);
-    Table->setItemDelegateForColumn(4, new ModeDelegate);
+    Table->setItemDelegateForColumn(0, new CodingAlgorithmDelegate(Rules_Recommendations));
+    Table->setItemDelegateForColumn(1, new SamplingFrequencyDelegate(Rules_Recommendations));
+    Table->setItemDelegateForColumn(2, new BitRateDelegate(Rules_Recommendations));
+    Table->setItemDelegateForColumn(3, new WordLengthDelegate(Rules_Recommendations));
+    Table->setItemDelegateForColumn(4, new ModeDelegate(Rules_Recommendations));
 
     Table->resizeColumnsToContents();
     Table->resizeRowsToContents();

--- a/Source/GUI/Qt/GUI_Main_xxxx_CodingHistoryDialog.h
+++ b/Source/GUI/Qt/GUI_Main_xxxx_CodingHistoryDialog.h
@@ -104,7 +104,7 @@ class CodingHistoryDialog_Delegate : public QItemDelegate
     Q_OBJECT
 
 public:
-    CodingHistoryDialog_Delegate(QObject *parent = 0);
+    CodingHistoryDialog_Delegate(bool Rules_Recommendations, QObject *parent = 0);
 
     QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const;
 
@@ -115,6 +115,9 @@ public:
 
 protected:
     virtual void Fill(QComboBox* Editor) const {}
+
+private:
+    bool Rules_Recommendations;
 };
 
 //***************************************************************************
@@ -125,7 +128,7 @@ protected:
 class _NAME##Delegate : public CodingHistoryDialog_Delegate \
     { \
     public: \
-        _NAME##Delegate(QObject *parent = 0) : CodingHistoryDialog_Delegate() {} \
+        _NAME##Delegate(bool Rules_Recommendations, QObject *parent = 0) : CodingHistoryDialog_Delegate(Rules_Recommendations, parent) {} \
     \
     protected: \
         void Fill(QComboBox* Editor) const; \


### PR DESCRIPTION
If allowed by current ruleset.

Fixes #123