### PR TITLE
CLI: Print error if MD5 verification is requested and field is missing

### DIFF
--- a/Project/GNU/CLI/test/overwrite.sh
+++ b/Project/GNU/CLI/test/overwrite.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-# TODO: make bwfmetaedit returns error ?
-
 script_path="${PWD}/test"
 . ${script_path}/helpers.sh
 
@@ -19,7 +17,7 @@ if [ "${?}" -ne 0 ] ; then
 fi
 
 run_bwfmetaedit --reject-overwrite --Description="overwrite" "${test}/${testfile}"
-check_success
+check_failure
 if [ "${?}" -ne 0 ] ; then
     error "${test}/overwrite" "command failed"
 fi

--- a/Source/CLI/CLI_Main.cpp
+++ b/Source/CLI/CLI_Main.cpp
@@ -136,6 +136,9 @@ int main(int argc, char* argv[])
     else
         std::cerr<<C.Text_stderr.str()<<std::endl;
 
+    if (C.Text_stderr_Updated_Get())
+        return 1;
+
     return 0;
 }
 //---------------------------------------------------------------------------

--- a/Source/CLI/CommandLine_Parser.cpp
+++ b/Source/CLI/CommandLine_Parser.cpp
@@ -447,6 +447,7 @@ CL_OPTION(MD5_Verify)
 {
     C.GenerateMD5=true;
     C.VerifyMD5=true;
+    C.VerifyMD5_Force=true;
 
     return -2; //Continue
 }

--- a/Source/Common/Core.cpp
+++ b/Source/Common/Core.cpp
@@ -52,6 +52,7 @@ Core::Core()
     NewChunksAtTheEnd=false;
     GenerateMD5=false;
     VerifyMD5=false;
+    VerifyMD5_Force=false;
     EmbedMD5=false;
     EmbedMD5_AuthorizeOverWritting=false;
     Bext_DefaultVersion=0;
@@ -1743,6 +1744,7 @@ void Core::Options_Update(handlers::iterator &Handler)
         Handler->second.Riff->NewChunksAtTheEnd=NewChunksAtTheEnd;
         Handler->second.Riff->GenerateMD5=GenerateMD5;
         Handler->second.Riff->VerifyMD5=VerifyMD5;
+        Handler->second.Riff->VerifyMD5_Force=VerifyMD5_Force;
         Handler->second.Riff->EmbedMD5=EmbedMD5;
         Handler->second.Riff->EmbedMD5_AuthorizeOverWritting=EmbedMD5_AuthorizeOverWritting;
         Handler->second.Riff->Bext_DefaultVersion=Bext_DefaultVersion;

--- a/Source/Common/Core.h
+++ b/Source/Common/Core.h
@@ -101,6 +101,7 @@ public:
     bool                                NewChunksAtTheEnd;
     bool                                GenerateMD5;
     bool                                VerifyMD5;
+    bool                                VerifyMD5_Force;
     bool                                EmbedMD5;
     bool                                EmbedMD5_AuthorizeOverWritting;
     int8u                               Bext_DefaultVersion;

--- a/Source/Riff/Riff_Base.h
+++ b/Source/Riff/Riff_Base.h
@@ -215,6 +215,7 @@ public:
         bool                NewChunksAtTheEnd;
         bool                GenerateMD5;
         bool                VerifyMD5;
+        bool                VerifyMD5_Force;
         bool                EmbedMD5;
         bool                EmbedMD5_AuthorizeOverWritting;
         bool                Out_Buffer_File_TryModification;
@@ -247,6 +248,7 @@ public:
             NewChunksAtTheEnd=false;
             GenerateMD5=false;
             VerifyMD5=false;
+            VerifyMD5_Force=false;
             EmbedMD5=false;
             EmbedMD5_AuthorizeOverWritting=false;
             Out_Buffer_WriteAtEnd=false;

--- a/Source/Riff/Riff_Handler.h
+++ b/Source/Riff/Riff_Handler.h
@@ -107,6 +107,7 @@ public:
     bool            NewChunksAtTheEnd;
     bool            GenerateMD5;
     bool            VerifyMD5;
+    bool            VerifyMD5_Force;
     bool            EmbedMD5;
     bool            EmbedMD5_AuthorizeOverWritting;
     bool            Trace_UseDec;
@@ -134,7 +135,7 @@ private:
     bool      IsModified_Internal        (const string &Field);
     string    Core_Get_Internal          (bool IsBackuping=false);
     bool      IsModified_Get_Internal    ();
-    void      Options_Update_Internal    ();
+    void      Options_Update_Internal    (bool Update=true);
     string    Cue_Xml_Get                ();
     bool      Cue_Xml_Set                (const string& Xml, rules Rules);
     bool      Cue_Xml_To_Fields          (const string& Xml, string& cue_, string& labl, string& note, string& ltxt);


### PR DESCRIPTION
+ Non-zero return code on errors

Fixes #203, fixes  #204