### PR TITLE
Removed qt5-default in Ubuntu 21.04

### DIFF
--- a/Project/GNU/bwfmetaedit.dsc
+++ b/Project/GNU/bwfmetaedit.dsc
@@ -6,7 +6,7 @@ Version: 20.08-1
 Maintainer: Jerome Martinez <info@mediaarea.net>
 Homepage: http://mediainfo.sourceforge.net
 Standards-Version: 3.7.3
-Build-Depends: debhelper (>= 5), tofrodos, qtbase5-dev, qtdeclarative5-dev, qtquickcontrols2-5-dev, libqt5svg5-dev, qt5-default, zlib1g-dev, pkg-config, automake, autoconf, libtool
+Build-Depends: debhelper (>= 5), tofrodos, qtbase5-dev, qtdeclarative5-dev, qtquickcontrols2-5-dev, libqt5svg5-dev, qtchooser, qt5-qmake, qtbase5-dev-tools, zlib1g-dev, pkg-config, automake, autoconf, libtool
 Files:
  00000000000000000000000000000000 000000 bwfmetaedit_20.08.orig.tar.xz
  00000000000000000000000000000000 000000 bwfmetaedit_20.08-1.debian.tar.xz

--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: bwfmetaedit
 Priority: optional
 Maintainer: Jerome Martinez <info@mediaarea.net>
-Build-Depends: debhelper (>= 5), tofrodos, qtbase5-dev, qtdeclarative5-dev, qtquickcontrols2-5-dev, libqt5svg5-dev, qt5-default, pkg-config, automake, autoconf, libtool
+Build-Depends: debhelper (>= 5), tofrodos, qtbase5-dev, qtdeclarative5-dev, qtquickcontrols2-5-dev, libqt5svg5-dev, qtchooser, qt5-qmake, qtbase5-dev-tools, pkg-config, automake, autoconf, libtool
 Standards-Version: 3.7.3
 Section: libs
 Homepage: http://mediainfo.sourceforge.net

--- a/debian/rules
+++ b/debian/rules
@@ -3,6 +3,7 @@
 
 # Uncomment this to turn on verbose mode.
 export DH_VERBOSE=1
+export QT_SELECT=qt5
 
 configure: configure-stamp
 configure-stamp:


### PR DESCRIPTION
Signed-off-by: Maxime Gervais <gervais.maxime@gmail.com>